### PR TITLE
Add descriptive alt text to images

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -102,7 +102,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/ia/ia-front-page.png" class="img-fluid" alt="" />
+              <img src="/assets/img/portfolio/ia/ia-front-page.png" class="img-fluid" alt="Artificial Intelligence cover" />
               <a href="/en/portfolio_ia.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -113,7 +113,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/filmmaker/filmmaker-front-page.png" class="img-fluid" alt="" />
+              <img src="/assets/img/portfolio/filmmaker/filmmaker-front-page.png" class="img-fluid" alt="Filmmaker cover" />
               <a href="/en/portfolio_filmmaker.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -124,7 +124,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/direccion/director-front-page.png" class="img-fluid" alt="" />
+              <img src="/assets/img/portfolio/direccion/director-front-page.png" class="img-fluid" alt="Direction cover" />
               <a href="/en/portfolio_direction.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -135,7 +135,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/fotografia/photograph-front-page.png" class="img-fluid" alt="" />
+              <img src="/assets/img/portfolio/fotografia/photograph-front-page.png" class="img-fluid" alt="Photography cover" />
               <a href="/en/portfolio_photograph.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -199,7 +199,7 @@
   <!-- ======= Footer ======= -->
   <footer id="footer">
     <div class="container">
-      <img src="/assets/img/logo_footer.png" alt="" style="width:200px;height:200px;"> />
+      <img src="/assets/img/logo_footer.png" alt="Federico Strifezzo logo" style="width:200px;height:200px;">
       <div class="social-links">
         <a href="https://www.instagram.com/federicostrifezzo/" class="instagram" target="_blank" rel="noopener noreferrer"><i class="bx bxl-instagram"></i></a>
         <a href="https://www.linkedin.com/in/federico-strifezzo-b79853155/" class="linkedin" target="_blank" rel="noopener noreferrer"><i class="bx bxl-linkedin"></i></a>

--- a/en/portfolio_photograph.html
+++ b/en/portfolio_photograph.html
@@ -64,37 +64,37 @@
             <div class="portfolio-details-slider swiper">
               <div class="swiper-wrapper align-items-center">
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame1.jpg" />
+                  <img alt="Photograph 1" src="/assets/img/portfolio/fotografia/frame1.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame2.jpg" />
+                  <img alt="Photograph 2" src="/assets/img/portfolio/fotografia/frame2.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame3.jpg" />
+                  <img alt="Photograph 3" src="/assets/img/portfolio/fotografia/frame3.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame4.jpg" />
+                  <img alt="Photograph 4" src="/assets/img/portfolio/fotografia/frame4.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame5.jpg" />
+                  <img alt="Photograph 5" src="/assets/img/portfolio/fotografia/frame5.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame6.jpg" />
+                  <img alt="Photograph 6" src="/assets/img/portfolio/fotografia/frame6.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame7.jpg" />
+                  <img alt="Photograph 7" src="/assets/img/portfolio/fotografia/frame7.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame8.jpg" />
+                  <img alt="Photograph 8" src="/assets/img/portfolio/fotografia/frame8.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame9.jpg" />
+                  <img alt="Photograph 9" src="/assets/img/portfolio/fotografia/frame9.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame10.jpg" />
+                  <img alt="Photograph 10" src="/assets/img/portfolio/fotografia/frame10.jpg" />
                 </div>
                 <div class="swiper-slide">
-                  <img alt="" src="/assets/img/portfolio/fotografia/frame11.jpg" />
+                  <img alt="Photograph 11" src="/assets/img/portfolio/fotografia/frame11.jpg" />
                 </div>
               </div>
 

--- a/es/index.html
+++ b/es/index.html
@@ -106,7 +106,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/ia/ia-portada.png" class="img-fluid" alt="">
+              <img src="/assets/img/portfolio/ia/ia-portada.png" class="img-fluid" alt="Portada de Inteligencia Artificial">
               <a href="/es/portfolio_ia.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -117,7 +117,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/filmmaker/filmmaker-portada.png" class="img-fluid" alt="">
+              <img src="/assets/img/portfolio/filmmaker/filmmaker-portada.png" class="img-fluid" alt="Portada de Filmmaker">
               <a href="/es/portfolio_filmmaker.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -128,7 +128,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/direccion/direccion-portada.png" class="img-fluid" alt="">
+              <img src="/assets/img/portfolio/direccion/direccion-portada.png" class="img-fluid" alt="Portada de Dirección">
               <a href="/es/portfolio_direccion.html" class="portfolio-details-lightbox" data-glightbox="type: external">
                 <div class="portfolio-info">
                   <div class="portfolio-links"></div>
@@ -139,7 +139,7 @@
 
           <div class="col-lg-6 col-md-6 portfolio-item filter-web">
             <div class="portfolio-wrap">
-              <img src="/assets/img/portfolio/fotografia/fotografia-portada.png" class="img-fluid" alt="">
+              <img src="/assets/img/portfolio/fotografia/fotografia-portada.png" class="img-fluid" alt="Portada de Fotografía">
               <a href="/es/portfolio_fotografia.html" class="portfolio-details-lightbox"
                 data-glightbox="type: external">
                 <div class="portfolio-info">
@@ -201,7 +201,7 @@
   <!-- ======= Footer ======= -->
   <footer id="footer">
     <div class="container">
-      <img src="/assets/img/logo_footer.png" alt="" style="width:200px;height:200px;">
+      <img src="/assets/img/logo_footer.png" alt="Logo de Federico Strifezzo" style="width:200px;height:200px;">
       <div class="social-links">
         <a href="https://www.instagram.com/federicostrifezzo/" class="instagram" target="_blank" rel="noopener noreferrer"><i
             class="bx bxl-instagram"></i></a>

--- a/es/portfolio_fotografia.html
+++ b/es/portfolio_fotografia.html
@@ -70,37 +70,37 @@
               <div class="swiper-wrapper align-items-center">
 
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame1.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame1.jpg" alt="Fotografía 1">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame2.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame2.jpg" alt="Fotografía 2">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame3.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame3.jpg" alt="Fotografía 3">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame4.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame4.jpg" alt="Fotografía 4">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame5.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame5.jpg" alt="Fotografía 5">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame6.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame6.jpg" alt="Fotografía 6">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame7.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame7.jpg" alt="Fotografía 7">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame8.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame8.jpg" alt="Fotografía 8">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame9.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame9.jpg" alt="Fotografía 9">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame10.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame10.jpg" alt="Fotografía 10">
                 </div>
                 <div class="swiper-slide">
-                  <img src="/assets/img/portfolio/fotografia/frame11.jpg" alt="">
+                  <img src="/assets/img/portfolio/fotografia/frame11.jpg" alt="Fotografía 11">
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- add short descriptions to portfolio thumbnails on home pages
- label photographs in photography portfolio pages
- add alt text for footer logo

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc152c1ec8324a8c0ddecbc8da453