### PR TITLE
Refactor inline styles into stylesheet

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1064,3 +1064,37 @@ section {
   color: #fff;
   font-size: 13px;
 }
+
+/* Replaced inline styles */
+.lang-switcher {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 9999;
+}
+
+.lang-switcher a {
+  margin-right: 6px;
+}
+
+.lang-switcher a:last-child {
+  margin-right: 0;
+}
+
+.text-highlight {
+  color: #ed1c24;
+}
+
+.quotes-wrapper {
+  padding: 10% 30%;
+  color: white;
+}
+
+.quotes-pagination {
+  padding-top: 10%;
+}
+
+.footer-logo {
+  width: 200px;
+  height: 200px;
+}

--- a/en/index.html
+++ b/en/index.html
@@ -42,8 +42,8 @@
 
 <body>
   <!-- ======= Seccion Botones Idiomas ======= -->
-  <div class="lang-switcher" style="position:fixed;top:12px;right:12px;z-index:9999;">
-    <a class="btn btn-sm btn-outline-light" href="/es/index.html" style="margin-right:6px;">ES</a>
+  <div class="lang-switcher">
+    <a class="btn btn-sm btn-outline-light" href="/es/index.html">ES</a>
     <a class="btn btn-sm btn-outline-light" href="/en/index.html">EN</a>
   </div>
   <!-- Fin Seccion Botones Idiomas -->
@@ -70,22 +70,22 @@
         <div class="section-title">
           <!-- <h2>Sobre mí</h2> -->
           <p>
-            As a <span style="color: #ed1c24;">Filmmaker</span> and <span style="color: #ed1c24;">Editor</span>, 
+            As a <span class="text-highlight">Filmmaker</span> and <span class="text-highlight">Editor</span>, 
             I have worked on my own projects and those of others in film, television, advertising, and social media. 
             Throughout my career, I have worked in key areas such as 
-            <span style="color: #ed1c24;">directing</span>,  
-            <span style="color: #ed1c24;">screenwriting</span>, 
-            <span style="color: #ed1c24;">photography</span>, and 
-            <span style="color: #ed1c24;">editing</span>. 
-            I have a <span style="color: #ed1c24;">Master's degree in documentary journalism</span> and solid 
-            <span style="color: #ed1c24;">theoretical knowledge of audiovisual language.</span> <br> <br>
+            <span class="text-highlight">directing</span>,  
+            <span class="text-highlight">screenwriting</span>, 
+            <span class="text-highlight">photography</span>, and 
+            <span class="text-highlight">editing</span>. 
+            I have a <span class="text-highlight">Master's degree in documentary journalism</span> and solid 
+            <span class="text-highlight">theoretical knowledge of audiovisual language.</span> <br> <br>
             I currently specialize in the 
-            <span style="color: #ed1c24;">convergence between traditional cinematic narrative and generative artificial intelligence</span>, 
+            <span class="text-highlight">convergence between traditional cinematic narrative and generative artificial intelligence</span>, 
             having evolved toward the exploration and 
-            <span style="color: #ed1c24;">professional application of AI tools</span> in all stages of audiovisual production. <br> <br>
+            <span class="text-highlight">professional application of AI tools</span> in all stages of audiovisual production. <br> <br>
             I work on both 
-            <span style="color: #ed1c24;">fully AI-generated productions</span> and 
-            <span style="color: #ed1c24;">hybrid projects</span> 
+            <span class="text-highlight">fully AI-generated productions</span> and 
+            <span class="text-highlight">hybrid projects</span> 
             that integrate traditional techniques with emerging technologies, 
             ranging from experimental narrative projects to advertising campaigns and social media content.
           </p>
@@ -151,7 +151,7 @@
 
     <!-- ======= Seccion Frases ======= -->
     <section class="portfolio-details" id="portfolio-details">
-      <div class="col-lg-12" style="padding-left: 30%; padding-right: 30%; padding-top: 10%; padding-bottom: 10%; color: white;">
+      <div class="col-lg-12 quotes-wrapper">
         <div class="portfolio-details-slider swiper">
           <div class="swiper-wrapper align-items-center">
 
@@ -162,7 +162,7 @@
                   What we perceive is a halo of justice that emerges in the form of cinema, 
                   the language that often serves as a band-aid between so much inequality and mistreatment 
                   on certain important issues.”<br /><br />
-                  <span style="color: #ed1c24;">José Tripodero</span>
+                  <span class="text-highlight">José Tripodero</span>
                 </p>
               </div>
             </div>
@@ -172,7 +172,7 @@
                 “Strifezzo's camera has the merit of being there at just the right moments when the three women 
                 reminisce in the shelter that remained intact after 37 years (...) the trio interacts constantly, 
                 sharing that painful experience that took them a long time to put into words.”<br /><br />
-                <span style="color: #ed1c24;">Oscar Ranzani</span>
+                <span class="text-highlight">Oscar Ranzani</span>
               </p>
             </div>
 
@@ -181,13 +181,13 @@
                 “Filmmaker Federico Strifezzo fulfills the fundamental premise of the record: 
                 to turn memories into a sensitive, respectful, and denunciatory piece about the lack of visibility 
                 of women in their auxiliary role in the war sequence.”<br /><br />
-                <span style="color: #ed1c24;">Florencia Fico</span>
+                <span class="text-highlight">Florencia Fico</span>
               </p>
             </div>
 
           </div>
 
-          <div class="swiper-pagination" style="padding-top: 10%;"></div>
+          <div class="swiper-pagination quotes-pagination"></div>
         </div>
       </div>
     </section>
@@ -199,7 +199,7 @@
   <!-- ======= Footer ======= -->
   <footer id="footer">
     <div class="container">
-      <img loading="lazy" src="/assets/img/logo_footer.png" alt="Federico Strifezzo logo" style="width:200px;height:200px;">
+      <img loading="lazy" src="/assets/img/logo_footer.png" alt="Federico Strifezzo logo" class="footer-logo">
       <div class="social-links">
         <a href="https://www.instagram.com/federicostrifezzo/" class="instagram" target="_blank" rel="noopener noreferrer"><i class="bx bxl-instagram"></i></a>
         <a href="https://www.linkedin.com/in/federico-strifezzo-b79853155/" class="linkedin" target="_blank" rel="noopener noreferrer"><i class="bx bxl-linkedin"></i></a>

--- a/es/index.html
+++ b/es/index.html
@@ -45,8 +45,8 @@
 
 
 <body>
-  <div class="lang-switcher" style="position:fixed;top:12px;right:12px;z-index:9999;">
-    <a href="/es/index.html" class="btn btn-sm btn-outline-light" style="margin-right:6px;">ES</a>
+  <div class="lang-switcher">
+    <a href="/es/index.html" class="btn btn-sm btn-outline-light">ES</a>
     <a href="/en/index.html" class="btn btn-sm btn-outline-light">EN</a>
   </div>
   <!-- ======= Seccion Principal ======= -->
@@ -74,22 +74,22 @@
         <div class="section-title">
           <!-- <h2>Sobre mí</h2> -->
           <p>
-            Como <span style="color: #ed1c24;">Filmmaker</span> y <span style="color: #ed1c24;">Editor</span>, trabajé
+            Como <span class="text-highlight">Filmmaker</span> y <span class="text-highlight">Editor</span>, trabajé
             en proyectos propios y de terceros tanto en cine como en televisión, publicidad y redes sociales.
             A lo largo de mi carrera, me desempeñé en áreas claves como la 
-            <span style="color: #ed1c24;">Dirección</span>, el 
-            <span style="color: #ed1c24;">guion</span>, la 
-            <span style="color: #ed1c24;">fotografía</span> y la 
-            <span style="color: #ed1c24;">edición</span>. Soy 
-            <span style="color: #ed1c24;">Magíster en Periodismo Documental</span>, y cuento con 
-            <span style="color: #ed1c24;">sólidos conocimientos teóricos sobre el lenguaje audiovisual</span>. <br> <br>
+            <span class="text-highlight">Dirección</span>, el 
+            <span class="text-highlight">guion</span>, la 
+            <span class="text-highlight">fotografía</span> y la 
+            <span class="text-highlight">edición</span>. Soy 
+            <span class="text-highlight">Magíster en Periodismo Documental</span>, y cuento con 
+            <span class="text-highlight">sólidos conocimientos teóricos sobre el lenguaje audiovisual</span>. <br> <br>
             Actualmente me especializo en la 
-            <span style="color: #ed1c24;">convergencia entre narrativa cinematográfica tradicional e inteligencia artificial generativa</span>, 
+            <span class="text-highlight">convergencia entre narrativa cinematográfica tradicional e inteligencia artificial generativa</span>, 
             habiendo evolucionado hacia la exploración y 
-            <span style="color: #ed1c24;">aplicación profesional de herramientas de IA</span> en todas las etapas de producción audiovisual. <br> <br>
+            <span class="text-highlight">aplicación profesional de herramientas de IA</span> en todas las etapas de producción audiovisual. <br> <br>
             Trabajo tanto en 
-            <span style="color: #ed1c24;">producciones completamente generadas con IA</span> como en 
-            <span style="color: #ed1c24;">proyectos híbridos</span> que integran técnicas tradicionales con tecnologías emergentes, 
+            <span class="text-highlight">producciones completamente generadas con IA</span> como en 
+            <span class="text-highlight">proyectos híbridos</span> que integran técnicas tradicionales con tecnologías emergentes, 
             desde proyectos narrativos experimentales hasta campañas publicitarias y contenido para redes sociales.
           </p>
         </div>
@@ -156,8 +156,7 @@
 
     <!-- ======= Seccion Frases ======= -->
     <section id="portfolio-details" class="portfolio-details">
-      <div class="col-lg-12"
-        style="padding-left: 30%; padding-right: 30%; padding-top: 10%; padding-bottom: 10%; color: white;">
+      <div class="col-lg-12 quotes-wrapper">
         <div class="portfolio-details-slider swiper">
           <div class="swiper-wrapper align-items-center">
             <div class="swiper-slide">
@@ -167,7 +166,7 @@
                   el refugio que quedó intacto tras 37 años (…) el trío interactúa permanentemente, compartiendo aquella
                   dolorosa experiencia que les costó mucho tiempo poner en palabras”.<br><br>
 
-                  <span style="color: #ed1c24;">Oscar Ranzani - Página12</span>
+                  <span class="text-highlight">Oscar Ranzani - Página12</span>
                 </p>
               </div>
             </div>
@@ -177,7 +176,7 @@
                 una pieza sensible, respetuosa y denunciante sobre la carente visibilización de la mujer en su oficio
                 auxiliador en la secuencia bélica”.<br><br>
 
-                <span style="color: #ed1c24;">Florencia Fico - Cineargentinohoy.com</span>
+                <span class="text-highlight">Florencia Fico - Cineargentinohoy.com</span>
               </p>
             </div>
             <div class="swiper-slide">
@@ -186,11 +185,11 @@
                 percibe es un halo de justicia que emerge en forma de cine, el lenguaje que muchas veces viene a poner
                 un parche entre tanta desigualdad y destrato sobre ciertos temas importantes”.<br><br>
 
-                <span style="color: #ed1c24;">José Tripodero - Asalallena.com.ar</span>
+                <span class="text-highlight">José Tripodero - Asalallena.com.ar</span>
               </p>
             </div>
           </div>
-          <div class="swiper-pagination" style="padding-top: 10%;">
+          <div class="swiper-pagination quotes-pagination">
           </div>
         </div>
     </section>
@@ -201,7 +200,7 @@
   <!-- ======= Footer ======= -->
   <footer id="footer">
     <div class="container">
-      <img loading="lazy" src="/assets/img/logo_footer.png" alt="Logo de Federico Strifezzo" style="width:200px;height:200px;">
+      <img loading="lazy" src="/assets/img/logo_footer.png" alt="Logo de Federico Strifezzo" class="footer-logo">
       <div class="social-links">
         <a href="https://www.instagram.com/federicostrifezzo/" class="instagram" target="_blank" rel="noopener noreferrer"><i
             class="bx bxl-instagram"></i></a>


### PR DESCRIPTION
## Summary
- Centralize language switcher, highlight, quote slider, pagination, and footer logo styles in `assets/css/style.css`
- Replace inline `style` attributes in English and Spanish homepages with semantic classes

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll -v 4.3.2` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bce309b4d08324b156c3f8886b2793