### PR TITLE
Add social metadata to index pages

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -10,6 +10,16 @@
   <meta content="Federico Strifezzo, Documentary filmmaker, Audiovisual producer, Director, Cinema" name="keywords" />
   <meta name="google-site-verification" content="_BHe2VNRQlFtQtpXICkZfd4ks08kFdWSfj-QcQn9-U8" />
 
+  <meta property="og:title" content="Federico Strifezzo" />
+  <meta property="og:description" content="Official site of Federico Strifezzo, documentary filmmaker and director" />
+  <meta property="og:image" content="https://federicostrifezzo.com/assets/img/logo_favicon.webp" />
+  <meta property="og:url" content="https://federicostrifezzo.com/en/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Federico Strifezzo" />
+  <meta name="twitter:description" content="Official site of Federico Strifezzo, documentary filmmaker and director" />
+  <meta name="twitter:image" content="https://federicostrifezzo.com/assets/img/logo_favicon.webp" />
+
   <!-- Favicons -->
   <link href="/assets/img/logo_favicon.webp" rel="icon" />
   <link href="/assets/img/logo_favicon.webp" rel="apple-touch-icon" />

--- a/es/index.html
+++ b/es/index.html
@@ -10,6 +10,16 @@
   <meta content="Federico Strifezzo, Documentalista, Realizador Audiovisual, Director, Cine" name="keywords">
   <meta name="google-site-verification" content="_BHe2VNRQlFtQtpXICkZfd4ks08kFdWSfj-QcQn9-U8" />
 
+  <meta property="og:title" content="Federico Strifezzo">
+  <meta property="og:description" content="Sitio oficial de Federico Strifezzo, documentalista y director">
+  <meta property="og:image" content="https://federicostrifezzo.com/assets/img/logo_favicon.webp">
+  <meta property="og:url" content="https://federicostrifezzo.com/es/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Federico Strifezzo">
+  <meta name="twitter:description" content="Sitio oficial de Federico Strifezzo, documentalista y director">
+  <meta name="twitter:image" content="https://federicostrifezzo.com/assets/img/logo_favicon.webp">
+
   <!-- Favicons -->
   <link href="/assets/img/logo_favicon.webp" rel="icon">
   <link href="/assets/img/logo_favicon.webp" rel="apple-touch-icon">


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter meta tags to English and Spanish landing pages

## Testing
- `tidy -q -e en/index.html es/index.html` *(fails: command not found)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4c0af888324b04515e82f35a4df