### PR TITLE
fix: use absolute asset paths in Spanish direction page

### DIFF
--- a/es/portfolio_direccion.html
+++ b/es/portfolio_direccion.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 
 <head> 
   <meta charset="utf-8">
@@ -10,18 +10,18 @@
   <meta content="" name="keywords">
 
   <!-- Favicons -->
-  <link href="assets/img/logo_favicon.webp" rel="icon">
-  <link href="assets/img/logo_favicon.webp" rel="apple-touch-icon">
+  <link href="/assets/img/logo_favicon.webp" rel="icon">
+  <link href="/assets/img/logo_favicon.webp" rel="apple-touch-icon">
 
   <!-- Google Fonts -->
   <link href="https://fonts.cdnfonts.com/css/gobold" rel="stylesheet">
   <link href="https://fonts.cdnfonts.com/css/akrobat" rel="stylesheet">
 
   <!-- Vendor CSS Files -->
-  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Template Main CSS File -->
-  <link href="assets/css/style.css" rel="stylesheet">
+  <link href="/assets/css/style.css" rel="stylesheet">
 </head>
 
 <!-- Google tag (gtag.js) -->
@@ -70,7 +70,7 @@
   <!-- End #main -->
 
   <!-- Vendor JS Files -->
-  <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="/assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- set Spanish lang attribute on portfolio page
- use absolute asset paths for icons, CSS, and JS

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bcf0a87fe48324b3127dead3c12239